### PR TITLE
モーダル内でリンクが無効になるバグ修正

### DIFF
--- a/src/components/Modal/Modal.stories.mdx
+++ b/src/components/Modal/Modal.stories.mdx
@@ -16,11 +16,17 @@ import Modal from './Modal.vue';
       data() {
         return { visible: false, }
       },
+      methods: {
+        action() {
+          console.log('button pressed!')
+        },
+      },
       template: `
         <div>
           <button @click="visible=true">SHOW MODAL</button>
           <Modal :visible="visible" @close="visible = false">
-            <span>hello</span>
+            <button @click="action">button</button><br />
+            <a href="/">link</a>
           </Modal>
         </div>
       `,

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -20,7 +20,7 @@
           <div
             class="content"
             :class="{ panel }"
-            @click.prevent="e => e.stopPropagation()"
+            @click="e => e.stopPropagation()"
           >
             <slot />
           </div>


### PR DESCRIPTION
背景のクリックでcloseさせるためにつけているクリックイベントが、コンテンツ部分をクリックしたときにも発火しないように、コンテンツ部分のクリック `stopPropagation` しているのですが、それを指定する部分に @click.prevent しているのが原因でした。
preventを外したら動作することを、chrome、safari、firefooxで確認しました。