### PR TITLE
[fix] Avatarのデフォルト画像が正しく表示されない

### DIFF
--- a/src/assets/images/avatar_default.svg
+++ b/src/assets/images/avatar_default.svg
@@ -1,1 +1,0 @@
-<svg height="200" viewBox="0 0 200 200" width="200" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="m0 0h200v200h-200z" fill="#D7D9E3"/><g fill="#888A93"><circle cx="100" cy="71" r="53"/><path d="m179 200c0-37.555363-35.369505-68-79-68-43.6304952 0-79 30.444637-79 68s158 37.555363 158 0z"/></g></g></svg>

--- a/src/components/AvatarImg/AvatarImg.vue
+++ b/src/components/AvatarImg/AvatarImg.vue
@@ -10,22 +10,18 @@
 
 <script>
 import { defineComponent, computed } from '@vue/composition-api'
-import avatarDefault from '@/assets/images/avatar_default.svg'
+
+const avatarDefault =
+  'data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%22200%22%20viewBox%3D%220%200%20200%20200%22%20width%3D%22200%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22m0%200h200v200h-200z%22%20fill%3D%22%23D7D9E3%22%2F%3E%3Cg%20fill%3D%22%23888A93%22%3E%3Ccircle%20cx%3D%22100%22%20cy%3D%2271%22%20r%3D%2253%22%2F%3E%3Cpath%20d%3D%22m179%20200c0-37.555363-35.369505-68-79-68-43.6304952%200-79%2030.444637-79%2068s158%2037.555363%20158%200z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E'
 
 export default defineComponent({
   props: {
     src: {
       type: String,
     },
-    defaultSrc: {
-      type: String,
-      default: avatarDefault,
-    },
   },
   setup(props, context) {
-    const backgroundImage = computed(
-      () => `url(${props.src || props.defaultSrc})`
-    )
+    const backgroundImage = computed(() => `url(${props.src || avatarDefault})`)
     return {
       context,
       backgroundImage,


### PR DESCRIPTION
importされたときにAvatarのデフォルト画像のパスがリンク切れを起こすので、そこまで画像のコード量も多くないため、一旦base64変換したものを.vueに埋め込んで対応。
（外部の画像ファイルをうまく繋ぎ込む方法を @tkow さんに調査いただいています 🙇 ）