### PR TITLE
[fix] LAPRAS - スマホでTagを非表示にしようとしたときに出るモーダルの x ボタンが効かない(または推しにくくて押せていない)

### DIFF
--- a/src/components/ShortModal/ShortModal.vue
+++ b/src/components/ShortModal/ShortModal.vue
@@ -108,9 +108,8 @@ export default defineComponent({
 
 .close-wrap {
   position: absolute;
-  top: 0;
-  right: 0;
-  margin: 33px;
+  top: 33px;
+  right: 33px;
   text-align: right;
 
   &.outer-close {
@@ -146,8 +145,8 @@ export default defineComponent({
   overflow: hidden;
   border-radius: $corner-r;
   background: $white;
-  width: calc(100vw - 20px);
-  height: calc(100vh - 20px);
+  width: calc(100vw - 40px);
+  height: calc(100vh - 80px);
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
上にスペースがなかったので広げました。
iOSのChrome最新版で x ボタンが押せること確認しました 🙇🏿 

![IMG_0791](https://user-images.githubusercontent.com/5090244/102600785-a1acf800-4162-11eb-903b-6b591a670a5f.jpg)

https://github.com/lapras-inc/scouty/issues/9892