### PR TITLE
feat(protectedlink): 別タブで開くときは rel="noopener" をつける

### DIFF
--- a/src/components/ProtectedLink/ProtectedLink.stories.mdx
+++ b/src/components/ProtectedLink/ProtectedLink.stories.mdx
@@ -70,6 +70,20 @@ import ProtectedLink from './ProtectedLink.vue';
       `,
     }}
   </Story>
+  <Story name="target=_blank">
+    {{
+      components: { ProtectedLink },
+      template: `
+        <ProtectedLink
+          href="https://en.wikipedia.org/wiki/William_Shakespeare"
+          target="_blank"
+          rel="author"
+        >
+          author of Hamlet
+        </ProtectedLink>
+      `,
+    }}
+  </Story>
   <Story name="force permit any link">
     {{
       components: { ProtectedLink },

--- a/src/components/ProtectedLink/ProtectedLink.vue
+++ b/src/components/ProtectedLink/ProtectedLink.vue
@@ -1,5 +1,7 @@
 <template>
-  <a v-bind="$attrs" :href="_href"><slot></slot></a>
+  <a v-bind="$attrs" :href="_href" :rel="_rel" :target="target"
+    ><slot></slot
+  ></a>
 </template>
 
 <script lang="ts">
@@ -21,6 +23,8 @@ const filterXSSScheme = (attr: string | undefined): string | undefined => {
 type ProtectedLinkProps = {
   href: string | undefined
   force: boolean
+  rel: string | undefined
+  target: string | undefined
 }
 
 export default defineComponent<ProtectedLinkProps>({
@@ -39,11 +43,23 @@ export default defineComponent<ProtectedLinkProps>({
       type: Boolean,
       default: false,
     },
+    target: {
+      type: String,
+    },
+    rel: {
+      type: String,
+    },
   },
   computed: {
     _href(this: ProtectedLinkProps): string | undefined {
       if (this.force) return this.href
       return filterXSSScheme(this.href as string)
+    },
+    _rel(this: ProtectedLinkProps): string | undefined {
+      if (this.target === '_blank') {
+        return `noopener ${this.rel || ''}`.replace(/\s$/, '')
+      }
+      return this.rel
     },
   },
 })


### PR DESCRIPTION
re lapras-inc/scouty#10930

`target="_blank"` のときは `rel="noopener"` がつくようにして、タブナビング対策する