### PR TITLE
feat(protectedlink): HTTPSのような大文字リンクを不要に削除しない

### DIFF
--- a/src/components/ProtectedLink/ProtectedLink.vue
+++ b/src/components/ProtectedLink/ProtectedLink.vue
@@ -14,7 +14,7 @@ import { defineComponent } from '@vue/composition-api'
 // クエリパラメータとして:がvalueにある場合は、forceをつけることで許容する
 const filterXSSScheme = (attr: string | undefined): string | undefined => {
   if (!attr) return undefined
-  if (attr.includes(':') && !attr.match(/^https?:\/\//)) {
+  if (attr.includes(':') && !attr.match(/^https?:\/\//i, )) {
     return undefined
   }
   return attr


### PR DESCRIPTION
## 概要

渡されたhrefが大文字だったときにundeifnedになってしまう問題を修正しました。

