### PR TITLE
fix(modal): setup 関数内で watch() を使わないようにする

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, watch } from '@vue/composition-api'
+import { defineComponent } from '@vue/composition-api'
 
 import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 import Icon from '@/components/Icon/Icon.vue'
@@ -64,18 +64,17 @@ export default defineComponent({
       default: 10,
     },
   },
-  setup(props) {
-    watch(
-      () => props.visible,
-      visible => {
+  watch: {
+    visible: {
+      immediate: true,
+      handler(visible) {
+        const $el = document.body
         if (visible) {
-          disableBodyScroll(document.body)
-        } else {
-          clearAllBodyScrollLocks()
+          return disableBodyScroll($el)
         }
-      }
-    )
-    return {}
+        clearAllBodyScrollLocks()
+      },
+    },
   },
 })
 </script>


### PR DESCRIPTION
読み込み側でエラーが出ていたので、急遽 https://github.com/lapras-inc/lapras-frontend/pull/139 のリファクタを戻しました

内容としては、 setup 関数の中で watch が使えないようでして、それを戻しました。
composition-api のバージョンを変えるなどでいけそうな気もしますが、一旦暫定の対応としてご確認お願いいたします。

<img width="661" alt="スクリーンショット 2022-02-10 16 03 05 2" src="https://user-images.githubusercontent.com/5090244/153377015-65d47762-7eb4-4b45-81cd-6074cad2a9d6.png">

