### PR TITLE
fix(textinput): v-on:input が使えなくなっていたので修正

### DIFF
--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -1,27 +1,25 @@
 <template>
   <textarea
     :value="value"
-    @input="e => onInput(e.target.value)"
     class="text-input is-multi-line"
     :class="{ 'has-error': error }"
     v-bind="context.attrs"
-    v-on="context.listeners"
+    v-on="inputListeners"
     v-if="multiline"
   ></textarea>
   <input
     :value="value"
-    @input="e => onInput(e.target.value)"
     class="text-input is-single-line"
     :class="{ 'has-error': error }"
     type="text"
     v-bind="context.attrs"
-    v-on="context.listeners"
+    v-on="inputListeners"
     v-else
   />
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api'
+import { defineComponent, computed } from '@vue/composition-api'
 
 export default defineComponent({
   props: {
@@ -39,10 +37,16 @@ export default defineComponent({
     },
   },
   setup(_, context) {
-    const onInput = (value: string) => context.emit('input', value)
+    const inputListeners = computed(() => {
+      return Object.assign({}, context.listeners, {
+        input: (e: { target: HTMLInputElement }) => {
+          context.emit('input', e.target.value)
+        },
+      })
+    })
     return {
       context,
-      onInput,
+      inputListeners,
     }
   },
 })


### PR DESCRIPTION
## 変更点

#134 で v-on に外から触れるようにした際に、既存の v-on:input で仕掛けたイベントが2重に呼ばれてしまう不具合があったので、修正しました

## before

これまで v-on:input のペイロードは入力値だったのに対して、 #134 以降はイベントが降ってくるように変わってしまい、 v-model が使えない状態になっていた。

<img width="295" alt="スクリーンショット 2022-03-02 11 00 41" src="https://user-images.githubusercontent.com/5090244/156280395-f9349609-4cee-4ad0-b093-3cd1ecf6c72d.png">

## after

<img width="278" alt="スクリーンショット 2022-03-02 11 01 01" src="https://user-images.githubusercontent.com/5090244/156280416-cadf33f3-0458-4835-a3df-711b1195d051.png">

## 動作確認

 - [x] Storybook の TextInput のページで、フィールドに値を入力すると正しく下に入力値が表示されること
        - http://localhost:6006/?path=/story/textinput--default-story