### PR TITLE
最新のlapras-frontendをLAPRAS, Scoutyで取り込めない件の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log*
 *.sln
 *.sw?
 
+dist

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@popperjs/core": "^2.2.1",
     "@types/body-scroll-lock": "^2.6.1",
-    "@vue/composition-api": "^0.5.0",
+    "@vue/composition-api": "^1.4.9",
     "body-scroll-lock": "^3.0.1",
     "core-js": "^3.6.4",
     "gh-pages": "^2.2.0",
@@ -61,7 +61,7 @@
     "sass": "^1.25.0",
     "sass-loader": "^8.0.2",
     "standard-version": "^8.0.0",
-    "typescript": "~3.7.5",
+    "typescript": "^4.6.2",
     "vue-cli-plugin-storybook": "^2.1.0",
     "vue-template-compiler": "^2.6.11"
   },

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -4,8 +4,10 @@
     class="text-input is-multi-line"
     :class="{ 'has-error': error }"
     v-bind="context.attrs"
-    v-on="inputListeners"
     v-if="multiline"
+    @input="$emit('input', $event.target.value)"
+    @focus="$emit('focus')"
+    @blur="$emit('blur')"
     ref="textarea"
   ></textarea>
   <input
@@ -14,7 +16,9 @@
     :class="{ 'has-error': error }"
     type="text"
     v-bind="context.attrs"
-    v-on="inputListeners"
+    @input="$emit('input', $event.target.value)"
+    @focus="$emit('focus')"
+    @blur="$emit('blur')"
     v-else
   />
 </template>
@@ -25,7 +29,6 @@ import {
   ref,
   watch,
   toRefs,
-  computed,
   nextTick,
 } from '@vue/composition-api'
 
@@ -53,14 +56,6 @@ export default defineComponent({
     },
   },
   setup(props, context) {
-    const inputListeners = computed(() => {
-      return Object.assign({}, context.listeners, {
-        input: (e: { target: HTMLInputElement }) => {
-          context.emit('input', e.target.value)
-        },
-      })
-    })
-
     const textarea = ref<HTMLElement | null>(null)
     const resizeTextareaIfAutoExpand = () => {
       if (textarea.value && props.autoExpand) {
@@ -85,7 +80,6 @@ export default defineComponent({
     return {
       context,
       textarea,
-      inputListeners,
     }
   },
 })

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -26,7 +26,7 @@ import {
   watch,
   toRefs,
   computed,
-  onMounted,
+  nextTick,
 } from '@vue/composition-api'
 
 export default defineComponent({
@@ -73,13 +73,14 @@ export default defineComponent({
     }
 
     const { value } = toRefs(props)
-    watch(value, () => {
-      resizeTextareaIfAutoExpand()
-    })
-
-    onMounted(() => {
-      resizeTextareaIfAutoExpand()
-    })
+    watch(
+      value,
+      async () => {
+        await nextTick()
+        resizeTextareaIfAutoExpand()
+      },
+      { immediate: true }
+    )
 
     return {
       context,

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -33,7 +33,7 @@ export default defineComponent({
   },
   props: {
     options: {
-      type: Object as PropType<PopperOptions>,
+      type: Object as PropType<Partial<PopperOptions>>,
       default: () => ({}),
     },
     skeleton: {
@@ -46,8 +46,8 @@ export default defineComponent({
     },
   },
   setup(props, context) {
-    const trigger = ref<HTMLElement>(null)
-    const container = ref<HTMLElement>(null)
+    const trigger = ref<HTMLElement | null>(null)
+    const container = ref<HTMLElement | null>(null)
     let popper: PopperInstance
 
     const hoverEvent = () => {
@@ -60,7 +60,7 @@ export default defineComponent({
       }
 
       popper = createPopper(trigger.value, container.value, {
-        placement: 'top' as Placement,
+        placement: 'top',
         ...props.options,
       })
     }

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -21,7 +21,6 @@
 import {
   createPopper,
   Options as PopperOptions,
-  Placement,
   Instance as PopperInstance,
 } from '@popperjs/core'
 import { defineComponent, PropType, ref } from '@vue/composition-api'

--- a/src/installCompositionApi.ts
+++ b/src/installCompositionApi.ts
@@ -1,0 +1,9 @@
+import Vue from 'vue'
+import VueCompositionAPI from '@vue/composition-api'
+
+// [vue-composition-api] must call Vue.use(plugin) before using any function.というエラーの対応
+// 読み込んだ Vue に Composition API が追加されていない場合は追加する
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+if (!(Vue as any)['__composition_api_installed__']) {
+  Vue.use(VueCompositionAPI)
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import './installCompositionApi'
 export { default as AvatarImg } from '@/components/AvatarImg/AvatarImg.vue'
 export { default as Card } from '@/components/Card/Card.vue'
 export { default as CheckBox } from '@/components/CheckBox/CheckBox.vue'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3898,12 +3898,10 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
-"@vue/composition-api@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.5.0.tgz#2dbaa02a5d1f5d0d407d53d5529fe444aa8362f3"
-  integrity sha512-9QDFWq7q839G1CTTaxeruPOTrrVOPSaVipJ2TxxK9QAruePNTHOGbOOFRpc8WLl4YPsu1/c29yBhMVmrXz8BZw==
-  dependencies:
-    tslib "^1.9.3"
+"@vue/composition-api@^1.4.9":
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.4.9.tgz#6fa65284f545887b52d421f23b4fa1c41bc0ad4b"
+  integrity sha512-l6YOeg5LEXmfPqyxAnBaCv1FMRw0OGKJ4m6nOWRm6ngt5TuHcj5ZoBRN+LXh3J0u6Ur3C4VA+RiKT+M0eItr/g==
 
 "@vue/eslint-config-prettier@^6.0.0":
   version "6.0.0"
@@ -15358,7 +15356,7 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
@@ -15480,10 +15478,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
# 目的

lapras-frontendの最新版をLAPRAS、Scoutyで読み込むと以下エラーが発生する件の修正

```
[vue-composition-api] must call Vue.use(plugin) before using any function.
```

# やったこと

詳細はコードにコメントします

# 動作確認

- [x] ローカルのLAPRAS, Scoutyのlapras-frontendのdistを本ブランチのビルド結果のdistで差し替えてエラーが発生しないこと
- [x] TextInputのauto expandが初期表示と入力で動くこと

