### PR TITLE
fix(component): shortModal で click を stopPropagation しない

### DIFF
--- a/src/components/ShortModal/ShortModal.vue
+++ b/src/components/ShortModal/ShortModal.vue
@@ -1,12 +1,13 @@
 <template>
   <transition name="fade">
-    <div class="modal" ref="modal" v-if="visible" @click="$emit('close')">
+    <div class="modal" ref="modal" v-if="visible">
       <div
         class="modal-overlay"
         :style="{
           background: filterBackground,
           zIndex,
         }"
+        @click="$emit('close')"
       ></div>
       <div
         class="modal-container"
@@ -17,16 +18,12 @@
       >
         <div class="modal-body">
           <div class="close-wrap" :class="{ 'outer-close': outerClose }">
-            <p class="close" v-if="hasClose">
+            <p class="close" v-if="hasClose" @click="$emit('close')">
               <Icon name="close" alt="閉じる" v-if="outerClose" />
               <i class="icon-cancel" v-else></i>
             </p>
           </div>
-          <div
-            class="content"
-            :class="{ panel }"
-            @click="e => e.stopPropagation()"
-          >
+          <div class="content" :class="{ panel }">
             <slot />
           </div>
         </div>


### PR DESCRIPTION
fix: https://github.com/lapras-inc/scouty/issues/13906

ShortModal で content の click イベントを stopPropagation してしまっていたため、issue にある Clipboard のようにイベントが body まで propagate されることを期待しているような処理がうまく機能しなくなっていました。

(このコンポーネントは tajima が作ったらしいのですが) あまりよく覚えていないんですが、多分 overlay と close ボタンの双方に click のハンドラを仕掛けるところを、横着して親にのみ click のハンドラをしかけて、代わりに content の click イベントを stopPropagation する、という阿呆なことをしていたみたいです。

横着しないようにしました。

lapras 側に無理矢理組み込んで issue になっているコピー機能が正常に機能することを確認しました。