### PR TITLE
fix(gitignore): remove dist from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ yarn-error.log*
 *.sln
 *.sw?
 
-dist


### PR DESCRIPTION
Because dist folder was added to '.gitignore', after icon is added, release workflow fails to update
files under ./dist/fonts and remove them. This behavior results in failure in docker-compose up
process.