### PR TITLE
ci: vue2.7の入ってないブランチでもリリースできるようにする

### DIFF
--- a/.github/workflows/npm-release-legacy.yml
+++ b/.github/workflows/npm-release-legacy.yml
@@ -1,0 +1,71 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: npm release legacy
+
+on:
+  push:
+    branches:
+      - legacy-release
+
+jobs:
+  publish-gpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+          scope: '@lapras-inc'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: build node package
+        run: yarn build
+      - name: Github config
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      - name: commit dist
+        run: |
+          git add -A
+          git diff-index --quiet HEAD || git commit -m 'chore: add dist'
+      - name: Version increment
+        run: yarn release
+      - name: Get package-version
+        id: package-version
+        run: echo "::set-output name=package_version::v$(node -p "require('./package.json').version")"
+      - name: GitHub Push
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          branch: legacy-release
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tags: true
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ steps.package-version.outputs.package_version }}
+          release_name: Release ${{ steps.package-version.outputs.package_version }}
+      - name: deploy github package registry
+        run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Storybook deploy
+        run: yarn storybook:build && yarn storybook:deploy:ci
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -50,5 +50,11 @@ zip解凍後、``$ for f in `ls`; do mv $f ${f/icomoon/scouty-icon}; done``で
 
 
 ## Release
+※ Vue2.6 >=
+1. `legacy-release`ブランチへのPRを手動で作成する
+2. [PRをマージするとGitHubでリリースされる](.github/workflows/npm-release-legacy.yml)
 
-- [releaseブランチにマージするとリリースされる](.github/workflows/npm-push-event.yml)
+※ Vue2.7
+1. `legacy`ブランチへのPRを作成する
+2. [PRをマージするとGitHubでリリースされる](.github/workflows/npm-release.yml)
+


### PR DESCRIPTION
`legacy-main`を`legacy-relese`に手動でマージすると自動でリリースされるようにしました。

`release`ブランチはバージョンが`0.1.x`, `legacy-release`ブランチは`0.0.x`になっているので、バージョンがぶつかることは無いと思います。  