### PR TITLE
ビルドがおかしくなっていたのを修正 

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  publicPath: '',
   css: {
     loaderOptions: {
       scss: {


### PR DESCRIPTION
https://github.com/lapras-inc/lapras-frontend/issues/204

## 事象
vue-cliを5系に上げたことで、アセットのパスの頭に`/`が付くようになり、アセットの解決ができなくなっていた

## やったこと
`publicPath`を設定し、`/`が付かないようにした。


<img width="530" alt="スクリーンショット 2023-01-11 18 38 38" src="https://user-images.githubusercontent.com/34234442/211775134-070d8040-1b14-4b8b-a14b-ce14d0f29f6b.png">

