### PR TITLE
inheritAttrs: falseの付与 & attrsの取り方を変える

### DIFF
--- a/src/components/AvatarImg/AvatarImg.vue
+++ b/src/components/AvatarImg/AvatarImg.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-bind="context.attrs"
+    v-bind="$attrs"
     :style="{ backgroundImage: `url(${src || avatarDefault})` }"
     class="avatar-icon"
     role="img"
@@ -20,10 +20,9 @@ export default defineComponent({
       type: String,
     },
   },
-  setup(props, context) {
+  setup() {
     return {
       avatarDefault,
-      context,
     }
   },
 })

--- a/src/components/AvatarImg/AvatarImg.vue
+++ b/src/components/AvatarImg/AvatarImg.vue
@@ -14,6 +14,7 @@ const avatarDefault =
   'data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%22200%22%20viewBox%3D%220%200%20200%20200%22%20width%3D%22200%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22m0%200h200v200h-200z%22%20fill%3D%22%23D7D9E3%22%2F%3E%3Cg%20fill%3D%22%23888A93%22%3E%3Ccircle%20cx%3D%22100%22%20cy%3D%2271%22%20r%3D%2253%22%2F%3E%3Cpath%20d%3D%22m179%20200c0-37.555363-35.369505-68-79-68-43.6304952%200-79%2030.444637-79%2068s158%2037.555363%20158%200z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E'
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     src: {
       type: String,

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="`is-skin-${skin}`" class="card" v-bind="context.attrs">
+  <div v-bind="$attrs" :class="`is-skin-${skin}`" class="card">
     <slot />
   </div>
 </template>
@@ -14,11 +14,6 @@ export default defineComponent({
       type: String as PropType<'default' | 'background' | 'background-line'>,
       default: 'default',
     },
-  },
-  setup(props, context) {
-    return {
-      context,
-    }
   },
 })
 </script>

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -8,6 +8,7 @@
 import { defineComponent, PropType } from 'vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     skin: {
       type: String as PropType<'default' | 'background' | 'background-line'>,

--- a/src/components/CheckBox/CheckBox.vue
+++ b/src/components/CheckBox/CheckBox.vue
@@ -18,6 +18,7 @@ import { defineComponent } from 'vue'
 import Icon from '@/components/Icon/Icon.vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   components: {
     Icon,
   },

--- a/src/components/CheckBox/CheckBox.vue
+++ b/src/components/CheckBox/CheckBox.vue
@@ -1,7 +1,7 @@
 <template>
   <label class="check-box" :class="{ 'is-disabled': disabled }">
     <input
-      v-bind="context.attrs"
+      v-bind="$attrs"
       :checked="modelValue"
       @change="onInput"
       class="input"
@@ -44,7 +44,6 @@ export default defineComponent({
     }
 
     return {
-      context,
       onInput,
     }
   },

--- a/src/components/EnhancedIconButton/EnhancedIconButton.vue
+++ b/src/components/EnhancedIconButton/EnhancedIconButton.vue
@@ -49,6 +49,7 @@
 import { defineComponent } from 'vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     tag: {
       type: String,

--- a/src/components/EnhancedIconButton/EnhancedIconButton.vue
+++ b/src/components/EnhancedIconButton/EnhancedIconButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="tag" class="enhanced-icon" v-bind="context.attrs">
+  <component v-bind="$attrs" :is="tag" class="enhanced-icon">
     <svg class="svg" viewBox="0 0 40 40">
       <defs>
         <circle id="path1" cx="20" cy="20" r="20"></circle>
@@ -55,11 +55,6 @@ export default defineComponent({
       type: String,
       default: 'button',
     },
-  },
-  setup(_, context) {
-    return {
-      context,
-    }
   },
 })
 </script>

--- a/src/components/FieldGroup/FieldGroup.vue
+++ b/src/components/FieldGroup/FieldGroup.vue
@@ -22,6 +22,7 @@
 import { defineComponent, PropType } from 'vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     label: {
       type: String,

--- a/src/components/FieldGroup/FieldGroup.vue
+++ b/src/components/FieldGroup/FieldGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="field-group" v-bind="context.attrs">
+  <div v-bind="$attrs" class="field-group">
     <div class="label-line" v-if="label">
       <p class="label">
         {{ label }}<small v-if="subLabel">{{ subLabel }}</small>
@@ -40,11 +40,6 @@ export default defineComponent({
       type: Boolean as PropType<boolean | null>,
       default: null,
     },
-  },
-  setup(props, context) {
-    return {
-      context,
-    }
   },
 })
 </script>

--- a/src/components/FlatButton/FlatButton.vue
+++ b/src/components/FlatButton/FlatButton.vue
@@ -21,6 +21,7 @@ import { defineComponent, PropType } from 'vue'
 import Icon from '@/components/Icon/Icon.vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   components: {
     Icon,
   },

--- a/src/components/FlatButton/FlatButton.vue
+++ b/src/components/FlatButton/FlatButton.vue
@@ -1,16 +1,16 @@
 <template>
   <component
-    v-bind="context.attrs"
+    v-bind="$attrs"
     :class="[`skin-${skin}`, `size-${size}`, enhanced && 'is-enhanced']"
     :disabled="disabled || undefined"
     :is="tag"
     class="flat-button"
   >
-    <div class="icon-wrap is-left" v-if="context.slots.leftIcon">
+    <div class="icon-wrap is-left" v-if="$slots.leftIcon">
       <slot name="leftIcon" />
     </div>
     <div class="body"><slot /></div>
-    <div class="icon-wrap is-right" v-if="context.slots.rightIcon">
+    <div class="icon-wrap is-right" v-if="$slots.rightIcon">
       <slot name="rightIcon" />
     </div>
   </component>
@@ -54,11 +54,6 @@ export default defineComponent({
       type: String,
       default: 'button',
     },
-  },
-  setup(props, context) {
-    return {
-      context,
-    }
   },
 })
 </script>

--- a/src/components/Icon/Icon.vue
+++ b/src/components/Icon/Icon.vue
@@ -9,6 +9,7 @@ import iconMap from './iconMap'
 type IconKey = keyof typeof iconMap
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     name: {
       type: String as PropType<IconKey>,

--- a/src/components/Icon/Icon.vue
+++ b/src/components/Icon/Icon.vue
@@ -1,5 +1,5 @@
 <template>
-  <i class="icon" v-bind="context.attrs">{{ iconMap[name] }}</i>
+  <i v-bind="$attrs" class="icon">{{ iconMap[name] }}</i>
 </template>
 
 <script lang="ts">
@@ -16,9 +16,8 @@ export default defineComponent({
       required: true,
     },
   },
-  setup(props, context) {
+  setup(props) {
     return {
-      context,
       iconMap,
     }
   },

--- a/src/components/Radio/Radio.vue
+++ b/src/components/Radio/Radio.vue
@@ -1,7 +1,7 @@
 <template>
   <label class="radio" :class="{ 'is-disabled': disabled }">
     <input
-      v-bind="context.attrs"
+      v-bind="$attrs"
       :checked="modelValue"
       @change="onInput"
       class="input"
@@ -38,7 +38,6 @@ export default defineComponent({
     const onInput = (e: Event) =>
       emitInput((e.target as HTMLInputElement).checked)
     return {
-      context,
       onInput,
     }
   },

--- a/src/components/Radio/Radio.vue
+++ b/src/components/Radio/Radio.vue
@@ -15,6 +15,7 @@
 import { defineComponent } from 'vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     modelValue: {
       type: Boolean,

--- a/src/components/RatingBar/RatingBar.vue
+++ b/src/components/RatingBar/RatingBar.vue
@@ -14,6 +14,7 @@
 import { defineComponent } from 'vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     max: {
       type: Number,

--- a/src/components/RatingBar/RatingBar.vue
+++ b/src/components/RatingBar/RatingBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="score-bar" v-bind="context.attrs">
+  <div v-bind="$attrs" class="score-bar">
     <div
       class="inner"
       :style="{
@@ -36,11 +36,6 @@ export default defineComponent({
       type: String,
       default: '#ff5a5f',
     },
-  },
-  setup(props, context) {
-    return {
-      context,
-    }
   },
 })
 </script>

--- a/src/components/TagLabel/TagLabel.vue
+++ b/src/components/TagLabel/TagLabel.vue
@@ -1,13 +1,13 @@
 <template>
   <div
+    v-bind="$attrs"
     :style="{ background: background, color: color }"
     class="tag-label"
-    v-bind="context.attrs"
   >
-    <p class="sub" v-if="context.slots.subLabel">
+    <p class="sub" v-if="$slots.subLabel">
       <slot name="subLabel" />
     </p>
-    <p class="main" :class="{ 'has-sub-label': context.slots.subLabel }">
+    <p class="main" :class="{ 'has-sub-label': $slots.subLabel }">
       <slot />
     </p>
   </div>
@@ -27,11 +27,6 @@ export default defineComponent({
       type: String,
       default: '#7F7F7F',
     },
-  },
-  setup(_, context) {
-    return {
-      context,
-    }
   },
 })
 </script>

--- a/src/components/TagLabel/TagLabel.vue
+++ b/src/components/TagLabel/TagLabel.vue
@@ -17,6 +17,7 @@
 import { defineComponent } from 'vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     background: {
       type: String,

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -27,6 +27,7 @@
 import { defineComponent, ref, watch, toRefs, nextTick } from 'vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     multiline: {
       type: Boolean,

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -1,6 +1,6 @@
 <template>
   <textarea
-    v-bind="context.attrs"
+    v-bind="$attrs"
     :value="modelValue"
     class="text-input is-multi-line"
     :class="{ 'has-error': error }"
@@ -11,7 +11,7 @@
     ref="textarea"
   ></textarea>
   <input
-    v-bind="context.attrs"
+    v-bind="$attrs"
     :value="modelValue"
     class="text-input is-single-line"
     :class="{ 'has-error': error }"
@@ -82,7 +82,6 @@ export default defineComponent({
     )
 
     return {
-      context,
       textarea,
       onInput,
     }

--- a/src/components/ToggleSwitch/ToggleSwitch.vue
+++ b/src/components/ToggleSwitch/ToggleSwitch.vue
@@ -1,7 +1,7 @@
 <template>
   <label class="toggle-switch">
     <input
-      v-bind="context.attrs"
+      v-bind="$attrs"
       :checked="modelValue"
       :disabled="disabled || undefined"
       @change="onInput"
@@ -37,9 +37,9 @@ export default defineComponent({
       context.emit('update:modelValue', value)
     const onInput = (e: Event) =>
       emitInput((e.target as HTMLInputElement).checked)
+
     return {
       onInput,
-      context,
     }
   },
 })

--- a/src/components/ToggleSwitch/ToggleSwitch.vue
+++ b/src/components/ToggleSwitch/ToggleSwitch.vue
@@ -18,6 +18,7 @@
 import { defineComponent } from 'vue'
 
 export default defineComponent({
+  inheritAttrs: false,
   props: {
     modelValue: {
       type: Boolean,

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <span class="tooltip">
     <span class="trigger" ref="trigger" @mouseenter="hoverEvent">
-      <slot name="trigger" /><Icon name="info" v-if="!context.slots.trigger" />
+      <slot name="trigger" /><Icon name="info" v-if="!$slots.trigger" />
     </span>
     <div class="container" ref="container">
       <div
@@ -44,7 +44,7 @@ export default defineComponent({
       default: 320,
     },
   },
-  setup(props, context) {
+  setup(props) {
     const trigger = ref<HTMLElement | null>(null)
     const container = ref<HTMLElement | null>(null)
     let popper: PopperInstance
@@ -64,7 +64,7 @@ export default defineComponent({
       })
     }
 
-    return { context, hoverEvent, trigger, container }
+    return { hoverEvent, trigger, container }
   },
 })
 </script>


### PR DESCRIPTION
https://github.com/lapras-inc/lapras-frontend/issues/203

### やったこと
※ 詳しくはIssue参照

- `v-bind="attrs"`を使っているコンポネに`inhertAttrs: false`を付与
- v-bindが一番上に書かれていない要素の修正（[参考](https://v3.ja.vuejs.org/guide/migration/v-bind.html#_2-x-%E3%81%A6%E3%82%99%E3%81%AE%E6%A7%8B%E6%96%87)）
- contextをreturnしてtemplate内で使っているところを修正

### 動作確認
修正した各コンポーネントの動作をStorybookで確認

### その他
まだ本番リリースされないのでザッとで大丈夫です！

`inheritAttrs: false`にしても、クラスやスタイルはVue2では自動でルート要素に受け継がれていたのですが、Vue3ではそれがなくなりました。
そのため、コンポーネントにクラスをつけたりしているところで崩れが生じる可能性がありますが、それはまあ後で直せばいいと思います
[参考](https://v3.ja.vuejs.org/guide/migration/attrs-includes-class-style.html)