### PR TITLE
refactor: 使用しない色変数を削除

### DIFF
--- a/src/stylesheets/variables/_index.scss
+++ b/src/stylesheets/variables/_index.scss
@@ -6,7 +6,6 @@ $lapras-blue: #1E86DE;
 $lapras-sec: #003089;
 $white: #FFFFFF;
 $lapras-mid-blue: #BCE0FD;
-$lapras-light-blue: #D6E3ED;
 $red: #ff5a5f;
 $orange: #FFAB00;
 $yellow: #FFD600;


### PR DESCRIPTION
色相が異なるため使用しない色変数を削除する
