### PR TITLE
bugfix: nojekyllのオプションを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "lint:commit": "commitlint",
     "release": "standard-version",
     "storybook:build": "storybook build",
-    "storybook:deploy": "gh-pages -d storybook-static",
-    "storybook:deploy:ci": "gh-pages -r 'https://action:'$GITHUB_TOKEN'@github.com/lapras-inc/lapras-frontend.git' -x -d storybook-static",
+    "storybook:deploy": "gh-pages --nojekyll -d storybook-static",
+    "storybook:deploy:ci": "gh-pages --nojekyll -r 'https://action:'$GITHUB_TOKEN'@github.com/lapras-inc/lapras-frontend.git' -x -d storybook-static",
     "test": "echo 'not implemented now'",
     "storybook:serve": "storybook dev -p 6006"
   },


### PR DESCRIPTION
github pagesでは、jekyllをデフォルトとしていて、`_`が先頭のファイルが配信されない。その関係で本番のみstorybookでエラーがでた。
明示的にjekyllでないことを伝えるoptionを設定。

参考: https://www.npmjs.com/package/gh-pages#optionsnojekyll

## エラー画面
<img width="1445" alt="image" src="https://github.com/user-attachments/assets/8f01bec2-ec8e-45f3-ab1f-9802b0cb1ae3">
