### PR TITLE
[fix] vueをdevdependenciesに移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "body-scroll-lock": "^3.1.5",
-    "core-js": "^3.37.1",
-    "vue": "3.4.34"
+    "core-js": "^3.37.1"
   },
   "devDependencies": {
+    "vue": "3.4.34",
     "@chromatic-com/storybook": "^1.6.1",
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",


### PR DESCRIPTION

vitest化で以下の問題に対処するために、devdependenciesに移動しました

https://github.com/lapras-inc/scouty/issues/22005#issuecomment-2301256166
