### PR TITLE
chore: node engineを22.11にupdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lapras-inc/lapras-frontend",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "author": "nasum <tomato.wonder.life@gmail.com>",
   "scripts": {
     "build": "npm run build:types && npm run build:vue",
@@ -83,7 +83,7 @@
     ]
   },
   "engines": {
-    "node": "20.x"
+    "node": ">=20.x <=22.x"
   },
   "peerDependencies": {
     "vue": "^3.4.34"


### PR DESCRIPTION
## 概要
node engineのバージョンをアップデート

- node engineバージョン変更
  - `20.x` to `22.11`
- lapras-frontendのバージョン変更
  - `0.3.5` to `0.3.6`
