### PR TITLE
Release 20241128145035

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lapras-inc/lapras-frontend",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "author": "nasum <tomato.wonder.life@gmail.com>",
   "scripts": {
     "build": "npm run build:types && npm run build:vue",
@@ -83,7 +83,7 @@
     ]
   },
   "engines": {
-    "node": "20.x"
+    "node": ">=20.x <=22.x"
   },
   "peerDependencies": {
     "vue": "^3.4.34"

--- a/src/components/AvatarImg/AvatarImg.vue
+++ b/src/components/AvatarImg/AvatarImg.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-bind="$attrs"
-    :style="{ backgroundImage: `url(${src || avatarDefault})` }"
+    :style="{ backgroundImage: `url('${src || avatarDefault}')` }"
     class="avatar-icon"
     role="img"
   ></div>


### PR DESCRIPTION
## リリース内容

https://lapras.esa.io/posts/741 に沿ってデプロイ作業を進めましょう

### 機能変更 の PR

担当者は PR の内容の確認結果でコメントを更新し、問題なければチェックをお願いします

- [ ] [#284](https://github.com/lapras-inc/lapras-frontend/pull/284): @lostfind chore: node engineを22.11にupdate

## ライブラリアップデート の PR

なし

## デザインレビューが必要な PR

なし

## QAレビューが必要な PR

なし

## News 投稿依頼が必要な PR

なし

## デプロイ後作業が必要な PR

なし
