### PR TITLE
fix: packageのバージョンは自動採番のため、変更前に戻す

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lapras-inc/lapras-frontend",
-  "version": "0.3.6",
+  "version": "0.3.5",
   "author": "nasum <tomato.wonder.life@gmail.com>",
   "scripts": {
     "build": "npm run build:types && npm run build:vue",


### PR DESCRIPTION
## 概要
`package.json`に記載するバージョンはrelease時にGitHub Actionにて採番されるため、masterを変更するとConflictが生じる。
https://github.com/lapras-inc/lapras-frontend/pull/284 で変更したversionを元の状態に戻す