### PR TITLE
chore(contentloader): ContentLoaderのランダム性を排除

### DIFF
--- a/src/components/ContentLoader/ContentLoader.stories.ts
+++ b/src/components/ContentLoader/ContentLoader.stories.ts
@@ -47,7 +47,7 @@ export const Default: Story = {
     type: 'PARAGRAPH',
     lineCount: 5,
     lineHeight: 1,
-    randomLineWidth: true,
+    randomLineWidth: false,
     gap: 0.8,
   },
 }


### PR DESCRIPTION
ContentLoaderのVRTでいつも差分が出るため、幅をランダムではなくしました。