### PR TITLE
fix(protectedlink): hrefはやはりundefined許容でよかったため修正

### DIFF
--- a/src/components/ProtectedLink/ProtectedLink.vue
+++ b/src/components/ProtectedLink/ProtectedLink.vue
@@ -34,7 +34,7 @@ const props = defineProps({
       }
       return true
     },
-    required: true,
+    default: undefined,
   },
   force: {
     type: Boolean,


### PR DESCRIPTION
リンクを無効化したい時にundefinedを付与するような使い方をしていたため